### PR TITLE
During check() make sure that $mirror is the same size.

### DIFF
--- a/jquery.expandable.js
+++ b/jquery.expandable.js
@@ -45,7 +45,7 @@
                     maxHeight = options.maxRows * rowSize;
                 }
 
-                // copy styles from textarea to mirror to mirror the textarea as best possible
+                // copy styles from textarea to mirror the textarea as best possible
                 $.each('borderTopWidth borderRightWidth borderBottomWidth borderLeftWidth paddingTop paddingRight paddingBottom paddingLeft fontSize fontFamily fontWeight fontStyle fontStretch fontVariant wordSpacing lineHeight width'.split(' '), function(i,prop) {
                     $mirror.css(prop, $this.css(prop));
                 });
@@ -59,6 +59,12 @@
                     });
 
                 function check() {
+                    //The size of the textarea may have changed because it's resizeable (due to jQuery, 
+                    //or allowable by the browser).  Update the mirror size in this case.
+                    $.each('borderTopWidth borderRightWidth borderBottomWidth borderLeftWidth width'.split(' '), function(i,prop) {
+                        $mirror.css(prop, $this.css(prop));
+                    });
+
                     var text = $this.val(), newHeight, height, usedHeight, usedRows, availableRows;
                     // copy textarea value to the $mirror
                     // encode any html passed in and replace new lines with a <br>


### PR DESCRIPTION
Hi Brandon,

Thank you very much for the jquery-expandable plugin, I plan on using this on a project I've been working on.

I noticed when I was playing with the example.html in Firefox 19.0 (which natively allows textarea resizing) that after I had resized the text area the increasing and decreasing height matching didn't work as expected.  If I made the text area wider, then the expansion would be quite a bit more than was needed, if smaller, then it wouldn't expand enough (and text would be hidden).

So, I believe that I've updated the code to prevent this by making sure the $mirror element is the same size as the text area when the check() function is called.

Best,
Ryan

P.S. This is my first pull request so apologies if I did anything incorrectly here.
